### PR TITLE
Update pyproject.toml with jaxmp/jaxls dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies=[
     "jax",  # gpu
     "moviepy",
     "kornia",
+    "jaxls @ git+https://github.com/chungmin99/jaxls@py310",
+    "jaxmp @ git+https://github.com/chungmin99/jaxmp@b1bfb99a1946ab7d177801758201f930aa179769",
 ]
 
 # need python3.12 (for jaxls)


### PR DESCRIPTION
- default `jaxls` and `jaxmp` are >=3.12 only.
- `jaxls` now points to a 3.10 compatible version; main difference is converting typing style.
- `jaxmp` should work -- but you should comment out the 3.12 dependency in the repo.